### PR TITLE
Fix: Correct UID references and address scene parsing errors

### DIFF
--- a/scenes/enemy_missile.tscn
+++ b/scenes/enemy_missile.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://d0gqjko6wlvf0"]
 
 [ext_resource type="Script" path="res://scripts/enemy_missile.gd" id="1_qrstuv"]
-[ext_resource type="Texture2D" uid="uid://cxyf07yq12j7g" path="res://icon.svg" id="2_wxyz0"]
+[ext_resource type="Texture2D" path="res://icon.svg" id="2_wxyz0"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_67890"]
 size = Vector2(48, 48) # Slightly larger for differentiation

--- a/scenes/player_projectile.tscn
+++ b/scenes/player_projectile.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://b5w5kgec255k8"]
 
 [ext_resource type="Script" path="res://scripts/player_projectile.gd" id="1_abcde"]
-[ext_resource type="Texture2D" uid="uid://cxyf07yq12j7g" path="res://icon.svg" id="2_fghij"]
+[ext_resource type="Texture2D" path="res://icon.svg" id="2_fghij"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_12345"]
 size = Vector2(32, 32) # Adjusted size to roughly match a scaled down icon


### PR DESCRIPTION
- I removed potentially problematic UIDs from `icon.svg` resource definitions in `enemy_missile.tscn` and `player_projectile.tscn`. This is intended to resolve fallback warnings and potentially fix related parsing issues.
- I investigated a `preload` error in `turret.tscn`. The direct cause was unclear but I hypothesize it to be related to the `icon.svg` UID issues. Removing UIDs is the first step to verify this.
- I believe other errors, such as 'Index out of bounds' and 'Invalid scene' for 'MissileSprite', are secondary to the primary parsing failures. I expect these to resolve if the main parsing issues are fixed.

Further testing in the Godot editor is required to confirm that all scene loading errors are fully resolved.