### PR TITLE
Fix: Workaround for turret.tscn preload error

### DIFF
--- a/scenes/turret.tscn
+++ b/scenes/turret.tscn
@@ -6,4 +6,3 @@
 script = ExtResource("1_wv12k")
 
 [node name="TurretSprite" type="Sprite2D" parent="."]
-texture = preload("res://icon.svg")

--- a/scripts/turret.gd
+++ b/scripts/turret.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+@onready var turret_sprite: Sprite2D = $TurretSprite
+
 const PlayerProjectile = preload("res://scenes/player_projectile.tscn")
 
 # Turret properties
@@ -10,6 +12,15 @@ var shoot_cooldown = 0.5 # Seconds
 var shoot_timer = null
 
 func _ready():
+    # Load and set texture for TurretSprite
+    var icon_tex = load("res://icon.svg")
+    if turret_sprite and icon_tex:
+        turret_sprite.texture = icon_tex
+    elif not turret_sprite:
+        printerr("TurretSprite node not found in turret.gd for icon assignment.")
+    elif not icon_tex:
+        printerr("Failed to load res://icon.svg in turret.gd.")
+
     # Timer for shoot cooldown
     shoot_timer = Timer.new()
     shoot_timer.wait_time = shoot_cooldown


### PR DESCRIPTION
- Modified `scenes/turret.tscn` to remove direct preloading of `icon.svg` for the TurretSprite's texture.
- Updated `scripts/turret.gd` to load `icon.svg` in the `_ready()` function and assign it to the TurretSprite's texture.

This change attempts to bypass the "Unexpected identifier: 'preload'" error that occurred when `preload` was used directly in the .tscn file. The previous attempt to fix this by removing UIDs from icon.svg in other scene files did not resolve the preload issue.

Further testing is needed to confirm if this workaround allows `turret.tscn` and subsequently `main_game.tscn` to load correctly.